### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,8 +52,13 @@ module.exports = function(input, output, cb) {
       }
 
       console.log(stdout);
-      fs.renameSync(outputFilePath, output);
-      cb();
+      try{
+        fs.renameSync(outputFilePath, output);
+        cb();
+      } catch (e) {
+        console.log(e);
+        return false;
+      }
     });
   }
 


### PR DESCRIPTION
Catch error instead of crash when renameSync() function fails.
