### PR TITLE
Fixes linux typo

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -18,7 +18,7 @@ module.exports = {
   getPngdefryBinPath: function() {
     var binPaths = {
       Darwin: path.join(__dirname, 'pngdefry', 'bin', 'osx', 'pngdefry'),
-      Linux: path.join(__dirname, 'pngdefry', 'bin', 'osx', 'pngdefry'),
+      Linux: path.join(__dirname, 'pngdefry', 'bin', 'linux', 'pngdefry'),
       Windows_NT: path.join(__dirname, 'pngdefry', 'bin', 'windows', 'pngdefry')
     };
 


### PR DESCRIPTION
This prevents it from working in linux due to it not finding the binary. I've tested it and it works after this change.
