### PR TITLE
Enable test code

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -11,28 +11,26 @@ var magic = new Magic();
 describe('Index', function() {
 
   describe('#pngdefry()', function() {
-    // it('should repair png success', function(done) {
-    it('should repair png success', function() {
-      // this.timeout(115000);
-      // var input = path.join(__dirname, 'img', 'icon.png');
-      // var output = path.join(__dirname, 'img', 'icon-new.png');
+    it('should repair png success', function(done) {
+      var input = path.join(__dirname, 'img', 'icon.png');
+      var output = path.join(__dirname, 'img', 'icon-new.png');
 
-      // pngdefry(input, output, function(err) {
-      //   if (err) {
-      //     return;
-      //   }
-      //
-      //   magic.detectFile(output, function(err, result) {
-      //     if (err) {
-      //       throw err;
-      //     }
-      //
-      //     // result=>PNG image data, 60 x 60, 8-bit/color RGBA, non-interlaced
-      //     result.should.match(/non-interlaced/);
-      //     fs.unlinkSync(output);
-      //     setTimeout(done, 110000);
-      //   });
-      // });
+      pngdefry(input, output, function(err) {
+        if (err) {
+          throw err;
+        }
+      
+        magic.detectFile(output, function(err, result) {
+          if (err) {
+            throw err;
+          }
+      
+          // result=>PNG image data, 60 x 60, 8-bit/color RGBA, non-interlaced
+          result.should.match(/non-interlaced/);
+          fs.unlinkSync(output);
+          done();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This pull request re-enables the test code and fixes an issue that was causing the tests to timeout when run on Linux (e.g. the Travis CI).

The cause of the hang was line 20, which previously read `return;` but which I have change to `throw err;`.

An error is being thrown here because of a typo in `lib/util.js` which is causing the wrong binary to be used when running on Linux. **This typo means that the test is currently failing**. This failure is expected. 

The typo has already been fixed by @tyrone-sudeium in #4 and I have confirmed that his change causes the test to pass.
