### PR TITLE
Additional error captured, and throw removed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,17 +62,17 @@ function convert(input, output, outputDir, outputFilePath, pngdefryBinPath, suff
       return cb('convert fail, not a PNG file');
     }
 
+    if (stdout.indexOf('not an -iphone crushed PNG file') > -1) {
+      return cb('convert fail, the png wasn\'t in the correct format');
+    }
+
     if (!util.fsExistsSync(outputFilePath)) {
       console.log('pngdefry is taking too much time to write the file on disk.');
     }
 
     console.log(stdout);
     fs.rename(outputFilePath, output, function(err) {
-      if (err) {
-        throw err;
-      }
-
-      cb();
+      cb(err);
     });
   });
 }


### PR DESCRIPTION
Hi, 
I've been using this lib in a project and for some reason while defrying a png extracted from an .ipa the converter reported the error `not an -iphone crushed PNG file`. 

I added code that in case of that issue, it immediately executed the callback with an error. 

I also removed the `throw` that was last in the code since if it got an error in the rename, the node process would die. Instead just give any error callback function and let the user decide what to do with it. 
