### PR TITLE
Change fs.mkdir to fs.mkdirSync

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -11,7 +11,7 @@ if (os.type() === 'Linux') {
   var pngdefryPath = path.join(process.cwd(), 'lib', 'pngdefry', 'source', 'pngdefry');
 
   if (!util.fsExistsSync(linuxPath)) {
-    fs.mkdir(linuxPath);
+    fs.mkdirSync(linuxPath);
   }
 
   var makeFileDir = path.join(process.cwd(), 'lib', 'pngdefry', 'source');


### PR DESCRIPTION
The following error occured when I tried to install `pngdefry`.
```
> pngdefry@1.1.6 postinstall /sd/workspace/src/ghe.corp.yahoo.co.jp/approduce/approduce/api/node_modules/pngdefry
> node postinstall.js

fs.js:137
    throw new ERR_INVALID_CALLBACK();
    ^

TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at makeCallback (fs.js:137:11)
    at Object.mkdir (fs.js:713:16)
    at Object.<anonymous> 
```

This problem is fixed by using `fs.mkdirSync`
```
$ node --version
v10.11.0

$ node
> let fs = require('fs')
undefined

> fs.mkdir('foobar')
TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at makeCallback (fs.js:137:11)
    at Object.mkdir (fs.js:713:16)

> fs.mkdirSync('foobar')
undefined
```
